### PR TITLE
Unmarshal

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -222,7 +222,7 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value) error {
 				if len(tags) > 0 {
 					rename := tags[0]
 					if len(rename) > 0 {
-						fieldName = tags[0]
+						fieldName = rename
 					}
 				}
 
@@ -274,6 +274,8 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value) error {
 					return NewUnmarshalError(node, fmt.Sprintf("attribute '%s' required", fieldName), nil)
 				}
 			case unmarshalText:
+				// Text needs a string field to get parsed into. We then collect any text inside this node or
+				// expect exactly one text in strict mode.
 				if field.Kind() != reflect.String {
 					return NewUnmarshalError(node, fmt.Sprintf("'%s' needs to have type string", fieldType.Name), nil)
 				}
@@ -301,7 +303,7 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value) error {
 				field.SetString(text.String())
 			default:
 				// Should never happen. We provide a helpful message just in case.
-				return fmt.Errorf("marshal in invalid state: unmarshalType=%v", unmarshalAs)
+				return fmt.Errorf("unmarshal in invalid state: unmarshalType=%v", unmarshalAs)
 			}
 		}
 	default:

--- a/marshal.go
+++ b/marshal.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © 2021 The tadl authors <https://github.com/golangee/tadl/blob/main/AUTHORS>
+// SPDX-License-Identifier: Apache-2.0
+
 package tadl
 
 import (

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,165 @@
+package tadl
+
+import (
+	"fmt"
+	"github.com/golangee/tadl/parser"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// Unmarshal takes Tadl input and parses it into the given struct.
+// If "into" is not a struct, this method will fail.
+// Strict mode requires that all fields of the struct are set and defined only once.
+// TODO Better error handling
+// TODO Nice mechanism for attributes
+func Unmarshal(r io.Reader, into interface{}, strict bool) error {
+	parse := parser.NewParser("", r)
+
+	tree, err := parse.Parse()
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal because of parser error: %w", err)
+	}
+
+	struc, err := prepareValue(into)
+	if err != nil {
+		return err
+	}
+
+	if err := unmarshalNode(tree, *struc, strict); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// unmarshalNode will place contents of the tadl node inside the given struct.
+// struc needs to be a struct, otherwise this method might panic.
+func unmarshalNode(node *parser.TreeNode, struc reflect.Value, strict bool) error {
+	for i := 0; i < struc.NumField(); i++ {
+		fieldType := struc.Type().Field(i)
+		field := struc.Field(i)
+
+		nodeChildren := findChildrenByName(node, fieldType.Name)
+
+		if len(nodeChildren) < 1 {
+			if strict {
+				return fmt.Errorf("'%s' not defined", fieldType.Name)
+			}
+
+			continue
+		} else if len(nodeChildren) > 1 && strict {
+			return fmt.Errorf("'%s' defined multiple times", fieldType.Name)
+		}
+
+		nodeForField := nodeChildren[0]
+
+		switch field.Kind() {
+		case reflect.String:
+			text, err := getTextChild(nodeForField)
+			if err != nil {
+				return fmt.Errorf("node for '%s' needs to have a text child", fieldType.Name)
+			}
+
+			field.SetString(text)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			text, err := getTextChild(nodeForField)
+			if err != nil {
+				return fmt.Errorf("node for '%s' needs to have a text child", fieldType.Name)
+			}
+
+			i, err := strconv.ParseInt(strings.TrimSpace(text), 10, 64)
+			if err != nil {
+				return fmt.Errorf("'%s' is not a valid integer", text)
+			}
+
+			if field.OverflowInt(i) {
+				return fmt.Errorf("value for '%s' out of bounds", fieldType.Name)
+			}
+
+			field.SetInt(i)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			text, err := getTextChild(nodeForField)
+			if err != nil {
+				return fmt.Errorf("node for '%s' needs to have a text child", fieldType.Name)
+			}
+
+			i, err := strconv.ParseUint(strings.TrimSpace(text), 10, 64)
+			if err != nil {
+				return fmt.Errorf("'%s' is not a valid integer", text)
+			}
+
+			if field.OverflowUint(i) {
+				return fmt.Errorf("value for '%s' out of bounds", fieldType.Name)
+			}
+
+			field.SetUint(i)
+		case reflect.Ptr:
+			return fmt.Errorf("pointer not supported yet")
+		case reflect.Array, reflect.Slice:
+			return fmt.Errorf("arrays not supported yet")
+		case reflect.Struct:
+			err := unmarshalNode(nodeForField, field, strict)
+			if err != nil {
+				return fmt.Errorf("error in '%s': %w", fieldType.Name, err)
+			}
+		default:
+			return fmt.Errorf("cannot unmarshal into '%s' with unsupported type '%v'", fieldType.Name, fieldType.Type)
+		}
+	}
+
+	return nil
+}
+
+// prepareValue accepts a struct or a struct behind any amount of pointers and returns
+// a reflect.Value that contains a struct. This returns an error if the given value
+// was not a struct.
+func prepareValue(v interface{}) (*reflect.Value, error) {
+	value := reflect.ValueOf(v)
+
+	for {
+		switch value.Kind() {
+		case reflect.Struct:
+			return &value, nil
+		case reflect.Ptr:
+			if value.IsNil() {
+				return nil, fmt.Errorf("cannot unmarshal into nil")
+			}
+
+			value = value.Elem()
+		default:
+			return nil, fmt.Errorf("can only unmarshal into struct")
+		}
+	}
+}
+
+// findChildrenByName returns all direct children of the given node that have
+// the given name.
+func findChildrenByName(node *parser.TreeNode, name string) []*parser.TreeNode {
+	var result []*parser.TreeNode
+
+	for _, child := range node.Children {
+		if child.Name == name {
+			result = append(result, child)
+		}
+	}
+
+	return result
+}
+
+// getTextChild will return a string from the CharData that is the child of the given node.
+// If node has more than 1 children this will return an error.
+// If the single child is not text, this will return an error.
+func getTextChild(node *parser.TreeNode) (string, error) {
+	if len(node.Children) != 1 {
+		return "", fmt.Errorf("only one child supported")
+	}
+
+	textChild := node.Children[0]
+	if !textChild.IsText() {
+		return "", fmt.Errorf("child is not text")
+	}
+
+	return *textChild.Text, nil
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -75,6 +75,19 @@ func TestUnmarshal(t *testing.T) {
 		},
 	})
 
+	type SimpleText struct {
+		Text string
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "simple test",
+		text: "#Text hello",
+		into: &SimpleText{},
+		want: &SimpleText{
+			Text: "hello",
+		},
+	})
+
 	testCases = append(testCases, TestCase{
 		name: "absent empty element is correctly parsed in non-strict mode",
 		text: "",
@@ -120,6 +133,24 @@ func TestUnmarshal(t *testing.T) {
 		want: &EmptyStructSlice{
 			Things: []Empty{{}, {}, {}},
 		},
+	})
+
+	testCases = append(testCases, TestCase{
+		name:    "do not unmarshal into nil",
+		text:    "whatever",
+		into:    nil,
+		wantErr: true,
+	})
+
+	type SimpleRename struct {
+		Field string `tadl:"item"`
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "field rename",
+		text: `#item hello`,
+		into: &SimpleRename{},
+		want: &SimpleRename{Field: "hello"},
 	})
 
 	// Run all test cases

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,109 @@
+package tadl
+
+import (
+	"github.com/r3labs/diff/v2"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshal(t *testing.T) {
+	// Base for testing
+	type TestCase struct {
+		text   string
+		strict bool
+		// into is an empty instance we will unmarshal into.
+		into interface{}
+		// want is a filled instance with all values we want.
+		want    interface{}
+		wantErr bool
+	}
+
+	var testCases []TestCase
+
+	type EmptyRoot struct{}
+
+	testCases = append(testCases, TestCase{
+		text: "",
+		into: &EmptyRoot{},
+		want: &EmptyRoot{},
+	})
+
+	type SimpleRoot struct {
+		S string
+		I int8
+		U uint64
+	}
+
+	testCases = append(testCases, TestCase{
+		text: "#S hello #I -5 #U 3000",
+		into: &SimpleRoot{},
+		want: &SimpleRoot{
+			S: "hello ",
+			I: -5,
+			U: 3000,
+		},
+	})
+
+	type OutOfBounds struct {
+		V int8
+	}
+
+	testCases = append(testCases, TestCase{
+		text:    "#V 300",
+		into:    &OutOfBounds{},
+		wantErr: true,
+	})
+
+	// Run all test cases
+	for _, tc := range testCases {
+		testName := reflect.ValueOf(tc.into).Elem().Type().Name()
+		t.Run(testName, func(t *testing.T) {
+			err := Unmarshal(strings.NewReader(tc.text), tc.into, tc.strict)
+
+			if err != nil {
+				if tc.wantErr {
+					// We got an expected error.
+					return
+				} else {
+					t.Fatal(err)
+				}
+			} else {
+				if tc.wantErr {
+					t.Fatal("expected an error, but got none")
+				}
+			}
+
+			differences, err := diff.Diff(tc.want, tc.into)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			// These descriptions map the type of a change to a more readable format.
+			changeTypeDescription := map[string]string{
+				"create": "was added",
+				"update": "is different",
+				"delete": "is missing",
+			}
+
+			if len(differences) > 0 {
+				for _, d := range differences {
+					nicePath := strings.Join(d.Path, ".")
+
+					// Skip differences on node ranges, as those are too noisy to test.
+					// This is a bit hacky, but is fine for testing. It would be nicer to
+					// have a custom recursive function to compare nodes.
+					if strings.Contains(nicePath, "Range.") {
+						continue
+					}
+
+					t.Errorf("property '%s' %s, expected %v but got %v",
+						nicePath,
+						changeTypeDescription[d.Type],
+						d.From, d.To)
+				}
+			}
+		})
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: © 2021 The tadl authors <https://github.com/golangee/tadl/blob/main/AUTHORS>
+// SPDX-License-Identifier: Apache-2.0
+
 package tadl
 
 import (

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,7 +1,9 @@
 package tadl
 
 import (
+	"fmt"
 	"github.com/r3labs/diff/v2"
+	"log"
 	"strings"
 	"testing"
 )
@@ -90,32 +92,32 @@ func TestUnmarshal(t *testing.T) {
 		wantErr: true,
 	})
 
-	type IntArray struct {
+	type IntSlice struct {
 		Nums []int
 	}
 
 	testCases = append(testCases, TestCase{
-		name: "int array",
+		name: "int slice",
 		text: `#!{
 					Nums {"1" "2" "3" "4"}
 				}`,
-		into: &IntArray{},
-		want: &IntArray{
+		into: &IntSlice{},
+		want: &IntSlice{
 			Nums: []int{1, 2, 3, 4},
 		},
 	})
 
-	type EmptyStructArray struct {
+	type EmptyStructSlice struct {
 		Things []Empty
 	}
 
 	testCases = append(testCases, TestCase{
-		name: "array of empty structs",
+		name: "slice of empty structs",
 		text: `#!{
 					Things {Empty, Empty, Empty}
 				}`,
-		into: &EmptyStructArray{},
-		want: &EmptyStructArray{
+		into: &EmptyStructSlice{},
+		want: &EmptyStructSlice{
 			Things: []Empty{{}, {}, {}},
 		},
 	})
@@ -140,7 +142,8 @@ func TestUnmarshal(t *testing.T) {
 
 			differences, err := diff.Diff(tc.want, tc.into)
 			if err != nil {
-				t.Error(err)
+				log.Println(fmt.Errorf("cannot compare test result: %w", err))
+				t.SkipNow()
 				return
 			}
 


### PR DESCRIPTION
Unmarshal unterstützt:

 * Verschachtelte structs
 * Primitive Datentypen
 * Umbenennen von Feldern
 * Tadl Text
 * Tadl Attribute

(Für eine genaue Beschreibung in marshal.go in den ersten Kommentar schauen.)

Es fehlt noch das Angeben von Verschachtelungen mit `tadl:"A>B>C"`, was Go in XML beherrscht. Wenn Bedarf danach besteht, baue ich das noch ein.