### PR TITLE
Unmarshal maps, slice behavior, inner

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -275,7 +275,6 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value, tags ...s
 		value.Set(reflect.MakeMap(valueType))
 		// A map will parse first level children as the key and the first child of those as the value.
 		for _, keyNode := range node.Children {
-
 			if !keyNode.IsNode() {
 				return NewUnmarshalError(node, "map key must be a node", nil)
 			}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -302,6 +302,55 @@ func TestUnmarshal(t *testing.T) {
 		wantErr: true,
 	})
 
+	type StringStringMap struct {
+		Things map[string]string
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "map[string]string",
+		text: `#!{
+					Things {
+						key1 value,
+						key2 "string value"
+					}
+				}`,
+		into: &StringStringMap{},
+		want: &StringStringMap{Things: map[string]string{
+			"key1": "value",
+			"key2": "string value",
+		}},
+	})
+
+	type BoolFloatMap struct {
+		Things map[bool]float64
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "map with primitive types",
+		text: `#!{
+					Things {
+						true 123,
+						false "123.456"
+					}
+				}`,
+		into: &BoolFloatMap{},
+		want: &BoolFloatMap{map[bool]float64{
+			true:  123,
+			false: 123.456,
+		}},
+	})
+
+	type InvalidMapKey struct {
+		Things map[*InvalidMapKey]int
+	}
+
+	testCases = append(testCases, TestCase{
+		name:    "invalid map key",
+		text:    "#Things",
+		into:    &InvalidMapKey{},
+		wantErr: true,
+	})
+
 	// Run all test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -27,6 +27,52 @@ func ExampleUnmarshal() {
 	// Output: Hello 3 year old Gopher !
 }
 
+func ExampleUnmarshal_Slice() {
+	type SimpleSlice struct {
+		Nums []int
+	}
+
+	input := strings.NewReader(`#!{
+		Nums {
+			1, 2, 3
+		}
+	}`)
+
+	var result SimpleSlice
+
+	Unmarshal(input, &result, false)
+
+	fmt.Print(result.Nums)
+	// Output: [1 2 3]
+}
+
+// ExampleComplexSlice demonstrates more complex slice usage.
+// Values will be placed in the correct slices because they
+// have a rename tag set.
+func ExampleUnmarshal_ComplexSlice() {
+
+	type ComplexArray struct {
+		Animals []string `tadl:"animal"`
+		Planets []string `tadl:"planet"`
+	}
+
+	input := strings.NewReader(`#!{
+		animal Dog,
+		planet Earth,
+		animal Cat,
+		animal Gopher,
+		planet Venus,
+		planet Mars
+	}`)
+
+	var result ComplexArray
+
+	Unmarshal(input, &result, false)
+
+	fmt.Printf("Animals: %s. Planets: %s.", strings.Join(result.Animals, ", "), strings.Join(result.Planets, ", "))
+	// Output: Animals: Dog, Cat, Gopher. Planets: Earth, Venus, Mars.
+}
+
 func TestUnmarshal(t *testing.T) {
 	// Base for testing
 	type TestCase struct {
@@ -135,7 +181,7 @@ func TestUnmarshal(t *testing.T) {
 	testCases = append(testCases, TestCase{
 		name: "int slice",
 		text: `#!{
-					Nums {"1" "2" "3" "4"}
+					Nums {1, 2, 3, 4}
 				}`,
 		into: &IntSlice{},
 		want: &IntSlice{
@@ -155,6 +201,28 @@ func TestUnmarshal(t *testing.T) {
 		into: &EmptyStructSlice{},
 		want: &EmptyStructSlice{
 			Things: []Empty{{}, {}, {}},
+		},
+	})
+
+	type FilteredSlice struct {
+		Ints []int `tadl:"i"`
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "filtered slice",
+		text: `#!{
+					i 1,
+					i 2,
+					hello 123,
+					i 3,
+					someitem 456,
+					"don't mind me"
+					some nested things,
+					i 4
+				}`,
+		into: &FilteredSlice{},
+		want: &FilteredSlice{
+			Ints: []int{1, 2, 3, 4},
 		},
 	})
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -50,7 +50,6 @@ func ExampleUnmarshal_Slice() {
 // Values will be placed in the correct slices because they
 // have a rename tag set.
 func ExampleUnmarshal_ComplexSlice() {
-
 	type Animal struct {
 		Name string `tadl:"name,attr"`
 		Age  uint   `tadl:"age"`


### PR DESCRIPTION
Beim Basteln der Architektursprache ist mir aufgefallen, dass das Verhalten von Unmarshal noch ein wenig inkonsistent war, daher gibts hier noch einen Schwung Features:

Maps:
 * primitive Datentypen als Key
 * primitive Datentypen als Value
 * parser.TreeNode als Value, falls man den Tree an der Stelle haben möchte, um komplexere Sachen zu tun. Interessant wäre hier in Zukunft, alle Datentypen als Value zuzulassen.

Slices:
 * Funktionieren jetzt einfacher und verständlicher, analog zu encoding/xml

Inner:
 * Die 'text' Annotation wurde durch 'inner' ersetzt, welche nicht nur Text, sondern alle auch sonst unterstützten Datentypen versteht.