### PR TITLE
Ignore comments while unmarshalling, nil values

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -249,6 +249,11 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value, tags ...s
 
 		value.SetFloat(f)
 	case reflect.Ptr:
+		// Create value for nil pointer
+		if value.IsNil() {
+			v := reflect.New(valueType.Elem())
+			value.Set(v)
+		}
 		// Dereference pointer
 		return u.node(node, value.Elem())
 	case reflect.Map:

--- a/marshal.go
+++ b/marshal.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Unmarshal takes Tadl input and parses it into the given struct.
-// If "into" is not a struct, this method will fail.
+// If "into" is not a struct or a pointer to a struct, this method will panic.
 // As this uses go's reflect package, only exported names can be unmarshalled.
 // Strict mode requires that all fields of the struct are set and defined exactly once.
 // You can set struct tags to influence the unmarshalling process.
@@ -111,7 +111,7 @@ func Unmarshal(r io.Reader, into interface{}, strict bool) error {
 	value := reflect.ValueOf(into)
 	unmarshal := unmarshaler{strict: strict}
 
-	if err := unmarshal.node(tree, value); err != nil {
+	if err := unmarshal.doAny(tree, value); err != nil {
 		return err
 	}
 
@@ -171,296 +171,379 @@ func (u *UnmarshalError) Unwrap() error {
 	return u.wrapping
 }
 
-// node will place contents of the tadl node inside the given value.
+// doAny will parse arbitrary contents of the tadl node into the given value.
 // tags are any field tags that may be relevant to process the current node.
-func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value, tags ...string) error {
-	valueType := value.Type()
-
+func (u *unmarshaler) doAny(node *parser.TreeNode, value reflect.Value, tags ...string) error {
 	switch value.Kind() {
 	case reflect.String:
-		text, err := u.findText(node)
+		err := u.doString(node, value)
 		if err != nil {
-			return NewUnmarshalError(node, "expected string", err)
+			return err
 		}
-
-		value.SetString(text)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		text, err := getAsText(node)
+		err := u.doInt(node, value)
 		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("integer required for '%s'", valueType.Name()), err)
+			return err
 		}
-
-		i, err := strconv.ParseInt(strings.TrimSpace(text), 10, 64)
-		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid integer", text), err)
-		}
-
-		if value.OverflowInt(i) {
-			return NewUnmarshalError(node, fmt.Sprintf("value for '%s' out of bounds", valueType.Name()), err)
-		}
-
-		value.SetInt(i)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		text, err := getAsText(node)
+		err := u.doUint(node, value)
 		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("unsigned integer required for '%s'", valueType.Name()), err)
+			return err
 		}
-
-		i, err := strconv.ParseUint(strings.TrimSpace(text), 10, 64)
-		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid unsigned integer", text), err)
-		}
-
-		if value.OverflowUint(i) {
-			return NewUnmarshalError(node, fmt.Sprintf("value for '%s' out of bounds", valueType.Name()), err)
-		}
-
-		value.SetUint(i)
 	case reflect.Bool:
-		text, err := getAsText(node)
+		err := u.doBool(node, value)
 		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("boolean required for '%s'", valueType.Name()), err)
+			return err
 		}
-
-		b, err := strconv.ParseBool(strings.TrimSpace(text))
-		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid boolean", text), err)
-		}
-
-		value.SetBool(b)
 	case reflect.Float64, reflect.Float32:
-		text, err := getAsText(node)
+		err := u.doFloat(node, value)
 		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("float required for '%s'", valueType.Name()), err)
+			return err
 		}
-
-		var bitSize int
-
-		switch value.Kind() {
-		case reflect.Float32:
-			bitSize = 32
-		case reflect.Float64:
-			bitSize = 64
-		}
-
-		f, err := strconv.ParseFloat(strings.TrimSpace(text), bitSize)
-		if err != nil {
-			return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid float", text), err)
-		}
-
-		value.SetFloat(f)
 	case reflect.Ptr:
-		// Create value for nil pointer
-		if value.IsNil() {
-			v := reflect.New(valueType.Elem())
-			value.Set(v)
-		}
-		// Dereference pointer
-		return u.node(node, value.Elem())
+		return u.doPointer(node, value)
 	case reflect.Map:
-		mapKeyType := valueType.Key()
-		mapValueType := valueType.Elem()
-
-		// Maps must have primitive key.
-		if !u.isPrimitive(mapKeyType) {
-			return NewUnmarshalError(node, fmt.Sprintf("map key type '%s' is not primitive", mapKeyType.String()), nil)
-		}
-
-		// Map value must be primitive or a (pointer to) parser.TreeNode
-		var valueMode unmarshalMapValue
-		if u.isPrimitive(mapValueType) {
-			valueMode = mapValueIsPrimitive
-		} else if mapValueType == reflect.TypeOf(parser.TreeNode{}) {
-			valueMode = mapValueIsNode
-		} else if mapValueType == reflect.TypeOf(&parser.TreeNode{}) {
-			valueMode = mapValueIsNodePointer
-		} else {
-			valueMode = mapValueIsCustomType
-		}
-
-		value.Set(reflect.MakeMap(valueType))
-		// A map will parse first level children as the key and the first child of those as the value.
-		for _, keyNode := range nonCommentChildren(node) {
-			if !keyNode.IsNode() {
-				if u.strict {
-					return NewUnmarshalError(node, "map key must be a node", nil)
-				} else {
-					continue
-				}
-			}
-
-			// Make mapKey be a zero value of the maps key type
-			mapKey := reflect.New(mapKeyType).Elem()
-
-			// In order to recursively use u.node() to parse values, we will forge a fake text node here
-			// and use that to recurse. We use this trick to parse both the key and the value.
-			fakeNode := parser.NewStringNode(keyNode.Name)
-			if err := u.node(fakeNode, mapKey); err != nil {
-				return NewUnmarshalError(node, "invalid map key", err)
-			}
-
-			// Now that we parsed the key we continue with parsing the value
-			keyNodeChildren := nonCommentChildren(keyNode)
-			if len(keyNodeChildren) == 0 {
-				return NewUnmarshalError(node, fmt.Sprintf("no value in map for key '%v'", mapKey), nil)
-			} else if u.strict && len(keyNodeChildren) != 1 {
-				return NewUnmarshalError(node, fmt.Sprintf("key '%v' needs exactly one value", mapKey), nil)
-			}
-
-			valueNode := keyNodeChildren[0]
-
-			// Make mapValue be a zero value of the maps value type
-			mapValue := reflect.New(mapValueType).Elem()
-
-			switch valueMode {
-			case mapValueIsNodePointer:
-				mapValue = reflect.ValueOf(keyNode)
-			case mapValueIsNode:
-				mapValue = reflect.ValueOf(*keyNode)
-			case mapValueIsCustomType:
-				if err := u.node(keyNode, mapValue, tags...); err != nil {
-					return err
-				}
-			case mapValueIsPrimitive:
-				if u.strict && len(nonCommentChildren(valueNode)) > 0 {
-					return NewUnmarshalError(node, fmt.Sprintf("value for key '%v' must have no children", mapKey), nil)
-				}
-
-				var primitiveValueToParse string
-
-				if valueNode.IsNode() {
-					primitiveValueToParse = valueNode.Name
-				} else if valueNode.IsText() {
-					primitiveValueToParse = *valueNode.Text
-				} else {
-					return NewUnmarshalError(node, fmt.Sprintf("value for key '%v' must be node or text", mapKey), nil)
-				}
-
-				fakeNode := parser.NewStringNode(primitiveValueToParse)
-				if err := u.node(fakeNode, mapValue); err != nil {
-					return NewUnmarshalError(node, "value is incompatible with map type", err)
-				}
-
-			default:
-				return NewUnmarshalError(node, fmt.Sprintf("unmarshal has invalid map value mode (%d). this is a bug", valueMode), nil)
-			}
-
-			value.SetMapIndex(mapKey, mapValue)
+		err := u.doMap(node, value, tags)
+		if err != nil {
+			return err
 		}
 	case reflect.Slice:
-		// Figure out type for elements. Should this be a slice we want to know what type is stored in it.
-		elementType := valueType.Elem()
-		if elementType.Kind() == reflect.Slice {
-			elementType = elementType.Elem()
-		}
-
-		// Create, process and append children
-		for _, child := range nonCommentChildren(node) {
-			if len(tags) > 0 {
-				// Use rename tag to filter for slice elements with the given name.
-				if child.Name != tags[0] {
-					continue
-				}
-			}
-
-			element := reflect.New(elementType).Elem()
-			if err := u.node(child, element); err != nil {
-				return NewUnmarshalError(node, fmt.Sprintf("cannot read slice children for '%s'", node.Name), err)
-			}
-
-			value.Set(reflect.Append(value, element))
+		err := u.doSlice(node, value, tags)
+		if err != nil {
+			return err
 		}
 	case reflect.Array:
 		return NewUnmarshalError(node, "arrays not supported, use a slice instead", nil)
 	case reflect.Struct:
-		// Iterate over all struct fields.
-		for i := 0; i < value.NumField(); i++ {
-			fieldType := value.Type().Field(i)
-			field := value.Field(i)
-
-			fieldName := fieldType.Name
-			unmarshalAs := unmarshalNormal
-
-			var tags []string
-
-			// Some tags will change the behavior of how this field will be processed.
-			if structTag, ok := fieldType.Tag.Lookup("tadl"); ok {
-				tags = strings.Split(structTag, ",")
-
-				// The first tag will rename the field
-				if len(tags) > 0 {
-					rename := tags[0]
-					if len(rename) > 0 {
-						fieldName = rename
-					}
-				}
-
-				// The second tag indicates the type we are parsing
-				if len(tags) > 1 {
-					as := tags[1]
-					switch as {
-					case "attr":
-						unmarshalAs = unmarshalAttribute
-					case "inner":
-						unmarshalAs = unmarshalInner
-					case "":
-						unmarshalAs = unmarshalNormal
-					default:
-						return NewUnmarshalError(node, fmt.Sprintf("field type '%s' invalid", as), nil)
-					}
-				}
-			}
-
-			switch unmarshalAs {
-			case unmarshalNormal:
-				// Should the field be a slice and a rename param is set, then we need to pass the whole node in,
-				// not just a subnode, to allow for filtering of elements.
-				if field.Kind() == reflect.Slice && len(tags) > 0 && len(tags[0]) > 0 {
-					if err := u.node(node, field, tags...); err != nil {
-						return err
-					}
-				} else {
-					nodeForField, err := u.findSingleChild(node, fieldName)
-					if err != nil {
-						return err
-					}
-
-					if nodeForField == nil {
-						continue
-					}
-
-					err = u.node(nodeForField, field, tags...)
-					if err != nil {
-						return NewUnmarshalError(node, fmt.Sprintf("while processing field '%s'", fieldType.Name), err)
-					}
-				}
-			case unmarshalAttribute:
-				if node.Attributes.Has(fieldName) {
-					// We have everything ready to set the attribute.
-					// We want to handle integers and strings easily so we recurse here by creating a fake node.
-					// As this node is a string, it can *only* be parsed as a primitive type, everything else
-					// will return an error, just like we want.
-					fakeNode := parser.NewStringNode(node.Attributes[fieldName])
-
-					err := u.node(fakeNode, field)
-					if err != nil {
-						// We throw away the error, as it was created with a fake node containing useless information.
-						return NewUnmarshalError(node, fmt.Sprintf("attribute '%s' requires primitve type", fieldName), nil)
-					}
-				} else if u.strict {
-					return NewUnmarshalError(node, fmt.Sprintf("attribute '%s' required", fieldName), nil)
-				}
-			case unmarshalInner:
-				if err := u.node(node, field); err != nil {
-					return NewUnmarshalError(node, "'inner' struct tag caused an error", err)
-				}
-			default:
-				// Should never happen. We provide a helpful message just in case.
-				return fmt.Errorf("unmarshal in invalid state: unmarshalType=%v. this is a bug", unmarshalAs)
-			}
+		err := u.doStruct(node, value)
+		if err != nil {
+			return err
 		}
 	default:
-		return NewUnmarshalError(node, fmt.Sprintf("with unsupported type '%s' for '%s'", valueType, valueType.Name()), nil)
+		return NewUnmarshalError(node, fmt.Sprintf("with unsupported type '%s' for '%s'", value.Type(), value.Type().Name()), nil)
+	}
+
+	return nil
+}
+
+// doSlice parses the children of the node as a slice into value. tags are needed to infer unmarshalling rules.
+func (u *unmarshaler) doSlice(node *parser.TreeNode, value reflect.Value, tags []string) error {
+	// Figure out type for elements. Should this be a slice we want to know what type is stored in it.
+	elementType := value.Type().Elem()
+	if elementType.Kind() == reflect.Slice {
+		elementType = elementType.Elem()
+	}
+
+	// Create, process and append children
+	for _, child := range nonCommentChildren(node) {
+		if len(tags) > 0 {
+			// Use rename tag to filter for slice elements with the given name.
+			if child.Name != tags[0] {
+				continue
+			}
+		}
+
+		element := reflect.New(elementType).Elem()
+		if err := u.doAny(child, element); err != nil {
+			return NewUnmarshalError(node, fmt.Sprintf("cannot read slice children for '%s'", node.Name), err)
+		}
+
+		value.Set(reflect.Append(value, element))
+	}
+
+	return nil
+}
+
+// doMap will parse the node as a map into value. tags are needed to infer unmarshalling rules.
+func (u *unmarshaler) doMap(node *parser.TreeNode, value reflect.Value, tags []string) error {
+	mapKeyType := value.Type().Key()
+	mapValueType := value.Type().Elem()
+
+	// Maps must have primitive key.
+	if !u.isPrimitive(mapKeyType) {
+		return NewUnmarshalError(node, fmt.Sprintf("map key type '%s' is not primitive", mapKeyType.String()), nil)
+	}
+
+	// Map value must be primitive or a (pointer to) parser.TreeNode
+	var valueMode unmarshalMapValue
+	if u.isPrimitive(mapValueType) {
+		valueMode = mapValueIsPrimitive
+	} else if mapValueType == reflect.TypeOf(parser.TreeNode{}) {
+		valueMode = mapValueIsNode
+	} else if mapValueType == reflect.TypeOf(&parser.TreeNode{}) {
+		valueMode = mapValueIsNodePointer
+	} else {
+		valueMode = mapValueIsCustomType
+	}
+
+	value.Set(reflect.MakeMap(value.Type()))
+	// A map will parse first level children as the key and the first child of those as the value.
+	for _, keyNode := range nonCommentChildren(node) {
+		if !keyNode.IsNode() {
+			if u.strict {
+				return NewUnmarshalError(node, "map key must be a node", nil)
+			} else {
+				continue
+			}
+		}
+
+		// Make mapKey be a zero value of the maps key type
+		mapKey := reflect.New(mapKeyType).Elem()
+
+		// In order to recursively use u.doAny() to parse values, we will forge a fake text node here
+		// and use that to recurse. We use this trick to parse both the key and the value.
+		fakeNode := parser.NewStringNode(keyNode.Name)
+		if err := u.doAny(fakeNode, mapKey); err != nil {
+			return NewUnmarshalError(node, "invalid map key", err)
+		}
+
+		// Now that we parsed the key we continue with parsing the value
+		keyNodeChildren := nonCommentChildren(keyNode)
+		if len(keyNodeChildren) == 0 {
+			return NewUnmarshalError(node, fmt.Sprintf("no value in map for key '%v'", mapKey), nil)
+		} else if u.strict && len(keyNodeChildren) != 1 {
+			return NewUnmarshalError(node, fmt.Sprintf("key '%v' needs exactly one value", mapKey), nil)
+		}
+
+		valueNode := keyNodeChildren[0]
+
+		// Make mapValue be a zero value of the maps value type
+		mapValue := reflect.New(mapValueType).Elem()
+
+		switch valueMode {
+		case mapValueIsNodePointer:
+			mapValue = reflect.ValueOf(keyNode)
+		case mapValueIsNode:
+			mapValue = reflect.ValueOf(*keyNode)
+		case mapValueIsCustomType:
+			if err := u.doAny(keyNode, mapValue, tags...); err != nil {
+				return err
+			}
+		case mapValueIsPrimitive:
+			if u.strict && len(nonCommentChildren(valueNode)) > 0 {
+				return NewUnmarshalError(node, fmt.Sprintf("value for key '%v' must have no children", mapKey), nil)
+			}
+
+			var primitiveValueToParse string
+
+			if valueNode.IsNode() {
+				primitiveValueToParse = valueNode.Name
+			} else if valueNode.IsText() {
+				primitiveValueToParse = *valueNode.Text
+			} else {
+				return NewUnmarshalError(node, fmt.Sprintf("value for key '%v' must be node or text", mapKey), nil)
+			}
+
+			fakeNode := parser.NewStringNode(primitiveValueToParse)
+			if err := u.doAny(fakeNode, mapValue); err != nil {
+				return NewUnmarshalError(node, "value is incompatible with map type", err)
+			}
+		default:
+			return NewUnmarshalError(node, fmt.Sprintf("unmarshal has invalid map value mode (%d). this is a bug", valueMode), nil)
+		}
+
+		value.SetMapIndex(mapKey, mapValue)
+	}
+
+	return nil
+}
+
+// doPointer will dereference the pointer in value or create a new zero value for it,
+// and then parse the node into that.
+func (u *unmarshaler) doPointer(node *parser.TreeNode, value reflect.Value) error {
+	// Create value for nil pointer
+	if value.IsNil() {
+		v := reflect.New(value.Type().Elem())
+		value.Set(v)
+	}
+	// Dereference pointer
+	return u.doAny(node, value.Elem())
+}
+
+// doFloat parses the node as a float into value.
+func (u *unmarshaler) doFloat(node *parser.TreeNode, value reflect.Value) error {
+	text, err := getAsText(node)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("float required for '%s'", value.Type().Name()), err)
+	}
+
+	var bitSize int
+
+	switch value.Kind() {
+	case reflect.Float32:
+		bitSize = 32
+	case reflect.Float64:
+		bitSize = 64
+	}
+
+	f, err := strconv.ParseFloat(strings.TrimSpace(text), bitSize)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid float", text), err)
+	}
+
+	value.SetFloat(f)
+
+	return nil
+}
+
+// doBool parses the node as a boolean into value.
+func (u *unmarshaler) doBool(node *parser.TreeNode, value reflect.Value) error {
+	text, err := getAsText(node)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("boolean required for '%s'", value.Type().Name()), err)
+	}
+
+	b, err := strconv.ParseBool(strings.TrimSpace(text))
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid boolean", text), err)
+	}
+
+	value.SetBool(b)
+
+	return nil
+}
+
+// doUint parses the node as an unsigned integer into value.
+func (u *unmarshaler) doUint(node *parser.TreeNode, value reflect.Value) error {
+	text, err := getAsText(node)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("unsigned integer required for '%s'", value.Type().Name()), err)
+	}
+
+	i, err := strconv.ParseUint(strings.TrimSpace(text), 10, 64)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid unsigned integer", text), err)
+	}
+
+	if value.OverflowUint(i) {
+		return NewUnmarshalError(node, fmt.Sprintf("value for '%s' out of bounds", value.Type().Name()), err)
+	}
+
+	value.SetUint(i)
+
+	return nil
+}
+
+// doInt parses the node as a signed integer into value.
+func (u *unmarshaler) doInt(node *parser.TreeNode, value reflect.Value) error {
+	text, err := getAsText(node)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("integer required for '%s'", value.Type().Name()), err)
+	}
+
+	i, err := strconv.ParseInt(strings.TrimSpace(text), 10, 64)
+	if err != nil {
+		return NewUnmarshalError(node, fmt.Sprintf("'%s' is not a valid integer", text), err)
+	}
+
+	if value.OverflowInt(i) {
+		return NewUnmarshalError(node, fmt.Sprintf("value for '%s' out of bounds", value.Type().Name()), err)
+	}
+
+	value.SetInt(i)
+
+	return nil
+}
+
+// doString parses the node as a string into value.
+func (u *unmarshaler) doString(node *parser.TreeNode, value reflect.Value) error {
+	text, err := u.findText(node)
+	if err != nil {
+		return NewUnmarshalError(node, "expected string", err)
+	}
+
+	value.SetString(text)
+
+	return nil
+}
+
+// doStruct parses the node as a struct into value.
+func (u *unmarshaler) doStruct(node *parser.TreeNode, value reflect.Value) error {
+	// Iterate over all struct fields.
+	for i := 0; i < value.NumField(); i++ {
+		fieldType := value.Type().Field(i)
+		field := value.Field(i)
+
+		fieldName := fieldType.Name
+		unmarshalAs := unmarshalNormal
+
+		var tags []string
+
+		// Some tags will change the behavior of how this field will be processed.
+		if structTag, ok := fieldType.Tag.Lookup("tadl"); ok {
+			tags = strings.Split(structTag, ",")
+
+			// The first tag will rename the field
+			if len(tags) > 0 {
+				rename := tags[0]
+				if len(rename) > 0 {
+					fieldName = rename
+				}
+			}
+
+			// The second tag indicates the type we are parsing
+			if len(tags) > 1 {
+				as := tags[1]
+				switch as {
+				case "attr":
+					unmarshalAs = unmarshalAttribute
+				case "inner":
+					unmarshalAs = unmarshalInner
+				case "":
+					unmarshalAs = unmarshalNormal
+				default:
+					return NewUnmarshalError(node, fmt.Sprintf("field type '%s' invalid", as), nil)
+				}
+			}
+		}
+
+		switch unmarshalAs {
+		case unmarshalNormal:
+			// Should the field be a slice and a rename param is set, then we need to pass the whole node in,
+			// not just a subnode, to allow for filtering of elements.
+			if field.Kind() == reflect.Slice && len(tags) > 0 && len(tags[0]) > 0 {
+				if err := u.doSlice(node, field, tags); err != nil {
+					return err
+				}
+			} else {
+				nodeForField, err := u.findSingleChild(node, fieldName)
+				if err != nil {
+					return err
+				}
+
+				if nodeForField == nil {
+					continue
+				}
+
+				err = u.doAny(nodeForField, field, tags...)
+				if err != nil {
+					return NewUnmarshalError(node, fmt.Sprintf("while processing field '%s'", fieldType.Name), err)
+				}
+			}
+		case unmarshalAttribute:
+			if node.Attributes.Has(fieldName) {
+				// We have everything ready to set the attribute.
+				// We want to handle integers and strings easily so we recurse here by creating a fake node.
+				// As this node is a string, it can *only* be parsed as a primitive type, everything else
+				// will return an error, just like we want.
+				fakeNode := parser.NewStringNode(node.Attributes[fieldName])
+
+				err := u.doAny(fakeNode, field)
+				if err != nil {
+					// We throw away the error, as it was created with a fake node containing useless information.
+					return NewUnmarshalError(node, fmt.Sprintf("attribute '%s' requires primitve type", fieldName), nil)
+				}
+			} else if u.strict {
+				return NewUnmarshalError(node, fmt.Sprintf("attribute '%s' required", fieldName), nil)
+			}
+		case unmarshalInner:
+			if err := u.doAny(node, field); err != nil {
+				return NewUnmarshalError(node, "'inner' struct tag caused an error", err)
+			}
+		default:
+			// Should never happen. We provide a helpful message just in case.
+			return fmt.Errorf("unmarshal in invalid state: unmarshalType=%v. this is a bug", unmarshalAs)
+		}
 	}
 
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -309,9 +309,9 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value, tags ...s
 
 			switch valueMode {
 			case mapValueIsNodePointer:
-				mapValue = reflect.ValueOf(valueNode)
+				mapValue = reflect.ValueOf(keyNode)
 			case mapValueIsNode:
-				mapValue = reflect.ValueOf(*valueNode)
+				mapValue = reflect.ValueOf(*keyNode)
 			case mapValueIsPrimitive:
 				if u.strict && len(nonCommentChildren(valueNode)) > 0 {
 					return NewUnmarshalError(node, fmt.Sprintf("value for key '%v' must have no children", mapKey), nil)

--- a/marshal.go
+++ b/marshal.go
@@ -180,13 +180,12 @@ func (u *UnmarshalError) Unwrap() error {
 // tags are any field tags that may be relevant to process the current node.
 func (u *unmarshaler) doAny(node *parser.TreeNode, value reflect.Value, tags ...string) error {
 	// Check for custom unmarshalling method.
-	iUnmarshal := reflect.TypeOf((*Unmarshaler)(nil)).Elem()
-	if value.Type().Implements(iUnmarshal) {
-		method := value.MethodByName("UnmarshalTadl")
+	customUnmarshalMethod := value.MethodByName("UnmarshalTadl")
+	if customUnmarshalMethod != *new(reflect.Value) {
 		params := []reflect.Value{reflect.ValueOf(node)}
 
 		// UnmarshalTadl might return an error.
-		errValue := method.Call(params)[0]
+		errValue := customUnmarshalMethod.Call(params)[0]
 		if !errValue.IsNil() {
 			return errValue.Interface().(error)
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -281,7 +281,11 @@ func (u *unmarshaler) node(node *parser.TreeNode, value reflect.Value, tags ...s
 		// A map will parse first level children as the key and the first child of those as the value.
 		for _, keyNode := range nonCommentChildren(node) {
 			if !keyNode.IsNode() {
-				return NewUnmarshalError(node, "map key must be a node", nil)
+				if u.strict {
+					return NewUnmarshalError(node, "map key must be a node", nil)
+				} else {
+					continue
+				}
 			}
 
 			// Make mapKey be a zero value of the maps key type

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -461,6 +461,24 @@ func TestUnmarshal(t *testing.T) {
 		wantErr: true,
 	})
 
+	type NillableThing struct {
+		Thing *Empty `tadl:"thing"`
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "nillable field is nil",
+		text: "",
+		into: &NillableThing{},
+		want: &NillableThing{Thing: nil},
+	})
+
+	testCases = append(testCases, TestCase{
+		name: "nillable field is set",
+		text: "#thing",
+		into: &NillableThing{},
+		want: &NillableThing{Thing: &Empty{}},
+	})
+
 	// Run all test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -197,6 +197,21 @@ func TestUnmarshal(t *testing.T) {
 		},
 	})
 
+	testCases = append(testCases, TestCase{
+		name: "int slice with comments",
+		text: `#!{
+					Nums {
+						1,
+						2, 3, // This comment should be ignored.
+						4
+					}
+				}`,
+		into: &IntSlice{},
+		want: &IntSlice{
+			Nums: []int{1, 2, 3, 4},
+		},
+	})
+
 	type EmptyStructSlice struct {
 		Things []Empty
 	}
@@ -221,6 +236,7 @@ func TestUnmarshal(t *testing.T) {
 		text: `#!{
 					i 1,
 					i 2,
+					// please ignore this comment
 					hello 123,
 					i 3,
 					someitem 456,
@@ -388,6 +404,24 @@ func TestUnmarshal(t *testing.T) {
 					Things {
 						key1 value,
 						key2 "string value"
+					}
+				}`,
+		into: &StringStringMap{},
+		want: &StringStringMap{Things: map[string]string{
+			"key1": "value",
+			"key2": "string value",
+		}},
+	})
+
+	testCases = append(testCases, TestCase{
+		name: "map with comments",
+		text: `#!{
+					Things {
+						// This comment should be ignored
+						key1 value,
+						// This comment should also be ignored
+						key2 "string value"
+						// This comment shall too be ignored
 					}
 				}`,
 		into: &StringStringMap{},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -517,6 +517,27 @@ func TestUnmarshal(t *testing.T) {
 		},
 	})
 
+	type StringA = string
+	type StringB string
+
+	type TypeAlias struct {
+		StringA StringA
+		StringB StringB
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "map with custom type as value",
+		text: `#!{
+					StringA "hello"
+					StringB "world"
+				}`,
+		into: &TypeAlias{},
+		want: &TypeAlias{
+			StringA: "hello",
+			StringB: "world",
+		},
+	})
+
 	// Run all test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -518,6 +518,7 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 	type StringA = string
+
 	type StringB string
 
 	type TypeAlias struct {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -552,7 +552,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 
 	testCases = append(testCases, TestCase{
-		name: "map with custom type as value",
+		name: "type alias",
 		text: `#!{
 					StringA "hello"
 					StringB "world"

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -479,6 +479,44 @@ func TestUnmarshal(t *testing.T) {
 		want: &NillableThing{Thing: &Empty{}},
 	})
 
+	type CustomMapValue struct {
+		Name  string
+		Value int
+	}
+
+	type MapWithCustomValue struct {
+		Map map[string]CustomMapValue
+	}
+
+	testCases = append(testCases, TestCase{
+		name: "map with custom type as value",
+		text: `#!{
+					Map {
+						thingA {
+							Name "this is thing A"
+							Value 3
+						}
+						thingB {
+							Name "this is thing B"
+							Value 5
+						}
+					}
+				}`,
+		into: &MapWithCustomValue{},
+		want: &MapWithCustomValue{
+			map[string]CustomMapValue{
+				"thingA": {
+					Name:  "this is thing A",
+					Value: 3,
+				},
+				"thingB": {
+					Name:  "this is thing B",
+					Value: 5,
+				},
+			},
+		},
+	})
+
 	// Run all test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -5,8 +5,10 @@ package tadl
 
 import (
 	"fmt"
+	"github.com/golangee/tadl/parser"
 	"github.com/r3labs/diff/v2"
 	"log"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -79,6 +81,29 @@ func ExampleUnmarshal_ComplexSlice() {
 
 	fmt.Printf("%s, %s", result.Animals[2].Name, result.Planets[0])
 	// Output: Gopher, Earth
+}
+
+// CustomUnmarshal is used to test the interface for implementing custom unmarshalling logic.
+// It will look for nodes named "Add" and parse the first child as an integer and sum them up.
+type CustomUnmarshal struct {
+	Sum int
+}
+
+func (c *CustomUnmarshal) UnmarshalTadl(node *parser.TreeNode) error {
+	for _, add := range node.Children {
+		if add.Name == "Add" {
+			iNode := add.Children[0]
+
+			i, err := strconv.Atoi(strings.TrimSpace(*iNode.Text))
+			if err != nil {
+				return err
+			}
+
+			c.Sum += i
+		}
+	}
+
+	return nil
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -537,6 +562,13 @@ func TestUnmarshal(t *testing.T) {
 			StringA: "hello",
 			StringB: "world",
 		},
+	})
+
+	testCases = append(testCases, TestCase{
+		name: "custom unmarshal",
+		text: "#Add 1 #Add 2 #Add 3",
+		into: &CustomUnmarshal{},
+		want: &CustomUnmarshal{Sum: 6},
 	})
 
 	// Run all test cases


### PR DESCRIPTION
 * Der Unmarshaler ignoriert jetzt Kommentare anstatt abzustürzen.
 * Pointer-Felder können auch verarbeitet werden und bleiben ggf. `nil`, wenn kein passendes Element da ist.
 * Eigene Types werden jetzt in Map Values unterstützt.
 * Ein neues Interface kann von structs für eigene Unmarshal-Logik implementiert werden.